### PR TITLE
[build] Setting up templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Compile '...'
+2. Run '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. CentOS 7.8]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Have questions
+    url: https://github.com/ververica/ForSt/discussions/categories/q-a
+    about: Please ask and answer questions here.
+  - name: New Ideas
+    url: https://github.com/ververica/ForSt/discussions/categories/ideas
+    about: Please suggest your new ideas here.

--- a/.github/ISSUE_TEMPLATE/work_item.md
+++ b/.github/ISSUE_TEMPLATE/work_item.md
@@ -1,0 +1,20 @@
+---
+name: Work Item
+about: Suggest/Log a work item (For big ideas and proposals, please go to New Ideas)
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**What is this for**
+A clear and concise description of what the item is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+<!--
+*Thank you very much for contributing to ForSt.
+
+## Contribution Checklist
+
+  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
+  
+  - Make sure that the change passes the automated tests.
+
+  - Each pull request should address only one issue, not mix up code from multiple issues.
+
+  - The title of this PR should start with module name, such as [build] / [core] / [JNI] ...
+-->
+
+## What is the purpose of the change
+
+*(For example: This pull request enables caching all the java classes that will be frequently used.)*
+
+
+## Brief change log
+
+*(for example:)*
+  - *A global cache container*
+  - *Cache entries for each objects*
+
+
+## Verifying this change
+
+*(Please pick either of the following options)*
+
+This change is a trivial rework / code cleanup without any test coverage.
+
+*(or)*
+
+This change is already covered by existing tests, such as *(please describe tests)*.
+
+*(or)*
+
+This change added tests and can be verified as follows:
+
+*(example:)*
+  - *first step*
+  - *second step*
+  - *third step, and xxx behaves as expected*

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,7 +1,0 @@
-> Note: Please use Issues only for bug reports. For questions, discussions, feature requests, etc. post to dev group: https://groups.google.com/forum/#!forum/rocksdb or https://www.facebook.com/groups/rocksdb.dev
-
-### Expected behavior
-
-### Actual behavior
-
-### Steps to reproduce the behavior


### PR DESCRIPTION
## What is the purpose of the change

This PR initializes the templates for issues and PRs.


## Brief change log
 - Some template files introduced under '.github'

## Verifying this change

Checked manually, example:
![image](https://github.com/ververica/ForSt/assets/2986149/955f283d-525d-404f-87b9-96cc5a77e216)
