### PR TITLE
[env] Fix jvm_util unused parameter error

### DIFF
--- a/env/flink/jvm_util.cc
+++ b/env/flink/jvm_util.cc
@@ -18,11 +18,14 @@
 
 #include "env/flink/jvm_util.h"
 
+#define UNUSED(x) (void)(x)
+
 namespace ROCKSDB_NAMESPACE {
 
 std::atomic<JavaVM*> jvm_ = std::atomic<JavaVM*>(nullptr);
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
+  UNUSED(reserved);
   JNIEnv* env = nullptr;
   if (vm->GetEnv((void**)&env, JNI_VERSION_1_8) != JNI_OK) {
     return -1;
@@ -33,6 +36,8 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
 }
 
 JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved) {
+  UNUSED(vm);
+  UNUSED(reserved);
   jvm_.store(nullptr);
 }
 


### PR DESCRIPTION

## What is the purpose of the change

This pull request fix jvm_util compile error which caused by unused parameters.

## Brief change log
- cast the unused parameters to void in jvm_util

## Verifying this change

This change is a trivial rework without any test coverage.
