### PR TITLE
[FLINK-36868] Use file system methods with string parameters via JNI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 #-----------------------------------------------
 
-FORST_VERSION ?= 0.1.3-beta
+FORST_VERSION ?= 0.1.4-beta
 
 BASH_EXISTS := $(shell which bash)
 SHELL := $(shell which bash)

--- a/env/flink/jni_helper.cc
+++ b/env/flink/jni_helper.cc
@@ -48,17 +48,14 @@ IOStatus JavaClassCache::Create(JNIEnv* env,
 
 IOStatus JavaClassCache::Init() {
   // Set all class names
-  cached_java_classes_[CachedJavaClass::JC_URI].className = "java/net/URI";
   cached_java_classes_[CachedJavaClass::JC_BYTE_BUFFER].className =
       "java/nio/ByteBuffer";
   cached_java_classes_[CachedJavaClass::JC_THROWABLE].className =
       "java/lang/Throwable";
-  cached_java_classes_[CachedJavaClass::JC_FLINK_PATH].className =
-      "org/apache/flink/core/fs/Path";
   cached_java_classes_[CachedJavaClass::JC_FLINK_FILE_SYSTEM].className =
-      "org/apache/flink/state/forst/fs/ForStFlinkFileSystem";
+      "org/apache/flink/state/forst/fs/StringifiedForStFileSystem";
   cached_java_classes_[CachedJavaClass::JC_FLINK_FILE_STATUS].className =
-      "org/apache/flink/core/fs/FileStatus";
+      "org/apache/flink/state/forst/fs/ForStFileStatus";
   cached_java_classes_[CachedJavaClass::JC_FLINK_FS_INPUT_STREAM].className =
       "org/apache/flink/state/forst/fs/ByteBufferReadableFSDataInputStream";
   cached_java_classes_[CachedJavaClass::JC_FLINK_FS_OUTPUT_STREAM].className =
@@ -76,33 +73,13 @@ IOStatus JavaClassCache::Init() {
   }
 
   // Set all method names, signatures and class infos
-  cached_java_methods_[CachedJavaMethod::JM_FLINK_PATH_CONSTRUCTOR]
-      .javaClassAndName = cached_java_classes_[JC_FLINK_PATH];
-  cached_java_methods_[CachedJavaMethod::JM_FLINK_PATH_CONSTRUCTOR].methodName =
-      "<init>";
-  cached_java_methods_[CachedJavaMethod::JM_FLINK_PATH_CONSTRUCTOR].signature =
-      "(Ljava/lang/String;)V";
-
-  cached_java_methods_[CachedJavaMethod::JM_FLINK_PATH_TO_STRING]
-      .javaClassAndName = cached_java_classes_[JC_FLINK_PATH];
-  cached_java_methods_[CachedJavaMethod::JM_FLINK_PATH_TO_STRING].methodName =
-      "toString";
-  cached_java_methods_[CachedJavaMethod::JM_FLINK_PATH_TO_STRING].signature =
-      "()Ljava/lang/String;";
-
-  cached_java_methods_[CachedJavaMethod::JM_FLINK_URI_CONSTRUCTOR]
-      .javaClassAndName = cached_java_classes_[JC_URI];
-  cached_java_methods_[CachedJavaMethod::JM_FLINK_URI_CONSTRUCTOR].methodName =
-      "<init>";
-  cached_java_methods_[CachedJavaMethod::JM_FLINK_URI_CONSTRUCTOR].signature =
-      "(Ljava/lang/String;)V";
-
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_GET]
       .javaClassAndName = cached_java_classes_[JC_FLINK_FILE_SYSTEM];
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_GET].methodName =
       "get";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_GET].signature =
-      "(Ljava/net/URI;)Lorg/apache/flink/core/fs/FileSystem;";
+      "(Ljava/lang/String;)Lorg/apache/flink/state/forst/fs/"
+      "StringifiedForStFileSystem;";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_GET].isStatic =
       true;
 
@@ -111,7 +88,7 @@ IOStatus JavaClassCache::Init() {
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_EXISTS]
       .methodName = "exists";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_EXISTS]
-      .signature = "(Lorg/apache/flink/core/fs/Path;)Z";
+      .signature = "(Ljava/lang/String;)Z";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_LIST_STATUS]
       .javaClassAndName = cached_java_classes_[JC_FLINK_FILE_SYSTEM];
@@ -119,7 +96,7 @@ IOStatus JavaClassCache::Init() {
       .methodName = "listStatus";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_LIST_STATUS]
       .signature =
-      "(Lorg/apache/flink/core/fs/Path;)[Lorg/apache/flink/core/fs/FileStatus;";
+      "(Ljava/lang/String;)[Lorg/apache/flink/state/forst/fs/ForStFileStatus;";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_GET_FILE_STATUS]
       .javaClassAndName = cached_java_classes_[JC_FLINK_FILE_SYSTEM];
@@ -127,44 +104,42 @@ IOStatus JavaClassCache::Init() {
       .methodName = "getFileStatus";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_GET_FILE_STATUS]
       .signature =
-      "(Lorg/apache/flink/core/fs/Path;)Lorg/apache/flink/core/fs/FileStatus;";
+      "(Ljava/lang/String;)Lorg/apache/flink/state/forst/fs/ForStFileStatus;";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_DELETE]
       .javaClassAndName = cached_java_classes_[JC_FLINK_FILE_SYSTEM];
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_DELETE]
       .methodName = "delete";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_DELETE]
-      .signature = "(Lorg/apache/flink/core/fs/Path;Z)Z";
+      .signature = "(Ljava/lang/String;Z)Z";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_MKDIR]
       .javaClassAndName = cached_java_classes_[JC_FLINK_FILE_SYSTEM];
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_MKDIR]
       .methodName = "mkdirs";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_MKDIR].signature =
-      "(Lorg/apache/flink/core/fs/Path;)Z";
+      "(Ljava/lang/String;)Z";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_RENAME_FILE]
       .javaClassAndName = cached_java_classes_[JC_FLINK_FILE_SYSTEM];
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_RENAME_FILE]
       .methodName = "rename";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_RENAME_FILE]
-      .signature =
-      "(Lorg/apache/flink/core/fs/Path;Lorg/apache/flink/core/fs/Path;)Z";
+      .signature = "(Ljava/lang/String;Ljava/lang/String;)Z";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_LINK_FILE]
       .javaClassAndName = cached_java_classes_[JC_FLINK_FILE_SYSTEM];
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_LINK_FILE]
       .methodName = "link";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_LINK_FILE]
-      .signature =
-      "(Lorg/apache/flink/core/fs/Path;Lorg/apache/flink/core/fs/Path;)I";
+      .signature = "(Ljava/lang/String;Ljava/lang/String;)I";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_OPEN]
       .javaClassAndName = cached_java_classes_[JC_FLINK_FILE_SYSTEM];
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_OPEN].methodName =
       "open";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_OPEN].signature =
-      "(Lorg/apache/flink/core/fs/Path;)Lorg/apache/flink/state/forst/fs/"
+      "(Ljava/lang/String;)Lorg/apache/flink/state/forst/fs/"
       "ByteBufferReadableFSDataInputStream;";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FS_INPUT_STREAM_SEQ_READ]
@@ -229,7 +204,7 @@ IOStatus JavaClassCache::Init() {
       .methodName = "create";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_SYSTEM_CREATE]
       .signature =
-      "(Lorg/apache/flink/core/fs/Path;)Lorg/apache/flink/state/forst/fs/"
+      "(Ljava/lang/String;)Lorg/apache/flink/state/forst/fs/"
       "ByteBufferWritableFSDataOutputStream;";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_STATUS_GET_PATH]
@@ -237,7 +212,7 @@ IOStatus JavaClassCache::Init() {
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_STATUS_GET_PATH]
       .methodName = "getPath";
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_STATUS_GET_PATH]
-      .signature = "()Lorg/apache/flink/core/fs/Path;";
+      .signature = "()Ljava/lang/String;";
 
   cached_java_methods_[CachedJavaMethod::JM_FLINK_FILE_STATUS_GET_LEN]
       .javaClassAndName = cached_java_classes_[JC_FLINK_FILE_STATUS];
@@ -313,29 +288,6 @@ JavaClassCache::JavaClassContext JavaClassCache::GetJClass(
 JavaClassCache::JavaMethodContext JavaClassCache::GetJMethod(
     CachedJavaMethod cachedJavaMethod) {
   return cached_java_methods_[cachedJavaMethod];
-}
-
-IOStatus JavaClassCache::ConstructPathInstance(const std::string& file_path,
-                                               jobject* pathInstance) {
-  JNIEnv* jniEnv = getJNIEnv();
-  JavaClassCache::JavaClassContext pathClass =
-      GetJClass(JavaClassCache::JC_FLINK_PATH);
-  JavaClassCache::JavaMethodContext pathConstructor =
-      GetJMethod(JavaClassCache::JM_FLINK_PATH_CONSTRUCTOR);
-  jstring pathString = jniEnv->NewStringUTF(file_path.c_str());
-  jobject tempPathInstance = jniEnv->NewObject(
-      pathClass.javaClass, pathConstructor.javaMethod, pathString);
-  jniEnv->DeleteLocalRef(pathString);
-  if (tempPathInstance == nullptr) {
-    return CheckThenError(std::string("Exception when ConstructPathInstance, ")
-                              .append(pathClass.ToString())
-                              .append(pathConstructor.ToString())
-                              .append(", args: Path(")
-                              .append(file_path)
-                              .append(")"));
-  }
-  *pathInstance = tempPathInstance;
-  return IOStatus::OK();
 }
 
 IOStatus CurrentStatus(

--- a/env/flink/jni_helper.h
+++ b/env/flink/jni_helper.h
@@ -29,10 +29,8 @@ class JavaClassCache {
  public:
   // Frequently-used class type representing jclasses which will be cached.
   typedef enum {
-    JC_URI,
     JC_BYTE_BUFFER,
     JC_THROWABLE,
-    JC_FLINK_PATH,
     JC_FLINK_FILE_SYSTEM,
     JC_FLINK_FILE_STATUS,
     JC_FLINK_FS_INPUT_STREAM,
@@ -42,9 +40,6 @@ class JavaClassCache {
 
   // Frequently-used method type representing jmethods which will be cached.
   typedef enum {
-    JM_FLINK_PATH_CONSTRUCTOR,
-    JM_FLINK_PATH_TO_STRING,
-    JM_FLINK_URI_CONSTRUCTOR,
     JM_FLINK_FILE_SYSTEM_GET,
     JM_FLINK_FILE_SYSTEM_EXISTS,
     JM_FLINK_FILE_SYSTEM_LIST_STATUS,
@@ -112,11 +107,6 @@ class JavaClassCache {
 
   // Get JavaMethodContext by specific CachedJavaMethod.
   JavaMethodContext GetJMethod(CachedJavaMethod cachedJavaMethod);
-
-  // Construct Java Path Instance based on cached classes and method related to
-  // Path.
-  IOStatus ConstructPathInstance(const std::string& /*file_path*/,
-                                 jobject* /*pathInstance*/);
 
  private:
   JNIEnv* jni_env_;

--- a/java/flinktestmock/src/main/java/org/apache/flink/state/forst/fs/ForStFileStatus.java
+++ b/java/flinktestmock/src/main/java/org/apache/flink/state/forst/fs/ForStFileStatus.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.fs;
+
+import org.apache.flink.core.fs.FileStatus;
+
+/**
+ * A wrapper of {@link FileStatus} just for ForSt. It will delegate all the methods from {@link
+ * FileStatus} and provide a version of primitive types. This class is used by JNI.
+ */
+public class ForStFileStatus {
+  private final FileStatus fileStatus;
+
+  public ForStFileStatus(FileStatus fileStatus) {
+    this.fileStatus = fileStatus;
+  }
+
+  public long getLen() {
+    return fileStatus.getLen();
+  }
+
+  public long getBlockSize() {
+    return fileStatus.getBlockSize();
+  }
+
+  public short getReplication() {
+    return fileStatus.getReplication();
+  }
+
+  public long getModificationTime() {
+    return fileStatus.getModificationTime();
+  }
+
+  public long getAccessTime() {
+    return fileStatus.getAccessTime();
+  }
+
+  public boolean isDir() {
+    return fileStatus.isDir();
+  }
+
+  public String getPath() {
+    return fileStatus.getPath().toString();
+  }
+}

--- a/java/flinktestmock/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
+++ b/java/flinktestmock/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
@@ -36,7 +36,7 @@ public class ForStFlinkFileSystem extends FileSystem {
     this.flinkFS = flinkFS;
   }
 
-  public static FileSystem get(URI uri) throws IOException {
+  public static ForStFlinkFileSystem get(URI uri) throws IOException {
     return new ForStFlinkFileSystem(FileSystem.get(uri));
   }
 

--- a/java/flinktestmock/src/main/java/org/apache/flink/state/forst/fs/StringifiedForStFileSystem.java
+++ b/java/flinktestmock/src/main/java/org/apache/flink/state/forst/fs/StringifiedForStFileSystem.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.fs;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import org.apache.flink.core.fs.Path;
+
+/**
+ * A {@link ForStFlinkFileSystem} stringifies all the parameters of all methods.
+ */
+public class StringifiedForStFileSystem {
+  private ForStFlinkFileSystem fileSystem;
+
+  public StringifiedForStFileSystem(ForStFlinkFileSystem fileSystem) {
+    this.fileSystem = fileSystem;
+  }
+
+  public static StringifiedForStFileSystem get(String uri) throws IOException {
+    return new StringifiedForStFileSystem(ForStFlinkFileSystem.get(URI.create(uri)));
+  }
+
+  public boolean exists(final String path) throws IOException {
+    return fileSystem.exists(new Path(path));
+  }
+
+  public ForStFileStatus getFileStatus(String path) throws IOException {
+    return new ForStFileStatus(fileSystem.getFileStatus(new Path(path)));
+  }
+
+  public ForStFileStatus[] listStatus(String path) throws IOException {
+    return Arrays.stream(fileSystem.listStatus(new Path(path)))
+        .map(ForStFileStatus::new)
+        .toArray(ForStFileStatus[] ::new);
+  }
+
+  public boolean delete(String path, boolean recursive) throws IOException {
+    return fileSystem.delete(new Path(path), recursive);
+  }
+
+  public boolean mkdirs(String path) throws IOException {
+    return fileSystem.mkdirs(new Path(path));
+  }
+
+  public boolean rename(String src, String dst) throws IOException {
+    return fileSystem.rename(new Path(src), new Path(dst));
+  }
+
+  public ByteBufferReadableFSDataInputStream open(String path) throws IOException {
+    return fileSystem.open(new Path(path));
+  }
+
+  public ByteBufferWritableFSDataOutputStream create(String path) throws IOException {
+    return fileSystem.create(new Path(path));
+  }
+
+  public int link(String src, String dst) throws IOException {
+    return fileSystem.link(new Path(src), new Path(dst));
+  }
+}

--- a/memory/arena_test.cc
+++ b/memory/arena_test.cc
@@ -12,6 +12,7 @@
 #ifndef OS_WIN
 #include <sys/resource.h>
 #endif
+#include "port/jemalloc_helper.h"
 #include "port/port.h"
 #include "test_util/testharness.h"
 #include "util/random.h"
@@ -267,7 +268,21 @@ TEST_F(ArenaTest, UnmappedAllocation) {
   // Verify that it's possible to get unmapped pages in large allocations,
   // for memory efficiency and to ensure we don't accidentally waste time &
   // space initializing the memory.
-  constexpr size_t kBlockSize = 2U << 20;
+
+#ifdef ROCKSDB_JEMALLOC
+  // With Jemalloc config.fill, the pages are written to before we get them
+  uint8_t fill = 0;
+  size_t fill_sz = sizeof(fill);
+  mallctl("config.fill", &fill, &fill_sz, nullptr, 0);
+  if (fill) {
+    ROCKSDB_GTEST_BYPASS("Test skipped because of config.fill==true");
+    return;
+  }
+#endif  // ROCKSDB_JEMALLOC
+
+  // This block size value is smaller than the smallest x86 huge page size,
+  // so should not be fulfilled by a transparent huge page mapping.
+  constexpr size_t kBlockSize = 1U << 20;
   Arena arena(kBlockSize);
 
   // The allocator might give us back recycled memory for a while, but


### PR DESCRIPTION
## What is the purpose of the change

Currently, the ForSt core use `ForStFlinkFileSystem` via JNI to manipulate files in Flink. However, the parameter and return value contains `Path`, which introduces redundant JNI call to convert from/to std::string. The Flink will provide methods with string directly. This PR change to use those methods.


## Brief change log

 - Necessary change in `jni_helper.cc` and `env_flink.cc`.

## Verifying this change

This change is already covered by existing tests.