### PR TITLE
[Java] Add shutdown hook to join background thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 #-----------------------------------------------
 
-FORST_VERSION ?= 0.1.5
+FORST_VERSION ?= 0.1.6
 
 BASH_EXISTS := $(shell which bash)
 SHELL := $(shell which bash)

--- a/java/src/main/java/org/forstdb/RocksDB.java
+++ b/java/src/main/java/org/forstdb/RocksDB.java
@@ -261,6 +261,7 @@ public class RocksDB extends RocksObject {
     final RocksDB db = new RocksDB(open(options.nativeHandle_, path));
     db.storeOptionsInstance(options);
     db.storeDefaultColumnFamilyHandle(db.makeDefaultColumnFamilyHandle());
+    RocksDBShutdownHook.register();
     return db;
   }
 
@@ -327,6 +328,8 @@ public class RocksDB extends RocksObject {
 
     db.ownedColumnFamilyHandles.addAll(columnFamilyHandles);
     db.storeDefaultColumnFamilyHandle(db.makeDefaultColumnFamilyHandle());
+
+    RocksDBShutdownHook.register();
 
     return db;
   }
@@ -402,6 +405,7 @@ public class RocksDB extends RocksObject {
     final RocksDB db = new RocksDB(openROnly(options.nativeHandle_, path, errorIfWalFileExists));
     db.storeOptionsInstance(options);
     db.storeDefaultColumnFamilyHandle(db.makeDefaultColumnFamilyHandle());
+    RocksDBShutdownHook.register();
     return db;
   }
 
@@ -514,6 +518,8 @@ public class RocksDB extends RocksObject {
     db.ownedColumnFamilyHandles.addAll(columnFamilyHandles);
     db.storeDefaultColumnFamilyHandle(db.makeDefaultColumnFamilyHandle());
 
+    RocksDBShutdownHook.register();
+
     return db;
   }
 
@@ -551,6 +557,7 @@ public class RocksDB extends RocksObject {
     final RocksDB db = new RocksDB(openAsSecondary(options.nativeHandle_, path, secondaryPath));
     db.storeOptionsInstance(options);
     db.storeDefaultColumnFamilyHandle(db.makeDefaultColumnFamilyHandle());
+    RocksDBShutdownHook.register();
     return db;
   }
 
@@ -612,6 +619,8 @@ public class RocksDB extends RocksObject {
 
     db.ownedColumnFamilyHandles.addAll(columnFamilyHandles);
     db.storeDefaultColumnFamilyHandle(db.makeDefaultColumnFamilyHandle());
+
+    RocksDBShutdownHook.register();
 
     return db;
   }

--- a/java/src/main/java/org/forstdb/RocksDBShutdownHook.java
+++ b/java/src/main/java/org/forstdb/RocksDBShutdownHook.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forstdb;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A shutdown hook to join threads before JVM quit, to avoid deadlock
+ * between VM threads and background threads.
+ * See https://github.com/ververica/ForSt/pull/30
+ */
+public class RocksDBShutdownHook {
+  private static final AtomicBoolean registered = new AtomicBoolean(false);
+
+  public static boolean register() {
+    if (registered.compareAndSet(false, true)) {
+      return register(() -> {
+        Env env = Env.getDefault();
+        if (env != null) {
+          env.setBackgroundThreads(0, Priority.LOW);
+          env.setBackgroundThreads(0, Priority.HIGH);
+        }
+      }, "Joining background threads");
+    }
+    return false;
+  }
+
+  private static boolean register(AutoCloseable service, String serviceName) {
+    final Thread shutdownHook = new Thread(() -> {
+      try {
+        service.close();
+      } catch (Throwable t) {
+        System.err.println("Error during shutdown of " + serviceName + " via JVM shutdown hook.");
+        t.printStackTrace(System.err);
+      }
+    }, serviceName + " shutdown hook");
+
+    try {
+      // Add JVM shutdown hook to call shutdown of service
+      Runtime.getRuntime().addShutdownHook(shutdownHook);
+      return true;
+    } catch (IllegalStateException e) {
+      // JVM is already shutting down. no need to do our work
+    } catch (Throwable t) {
+      System.err.println(
+          "Cannot register shutdown hook that cleanly terminates " + serviceName + ".");
+      t.printStackTrace(System.err);
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

When using the `FlinkEnv`, the background threads will call JVM provided `AttachCurrentThread` to call Java methods via JNI, and required to invoke `DetachCurrentThread` when exit. However, during the JVM exit, the background thread invokes the `DetachCurrentThread`, and is blocked at `wait_if_vm_exited`:
```
  thread #32
    frame #0: 0x000000018bceec08 libsystem_kernel.dylib`__psynch_mutexwait + 8
    frame #1: 0x000000018bd290c4 libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_wait + 84
    frame #2: 0x000000018bd26a5c libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_slow + 248
    frame #3: 0x0000000103bffbdc libjvm.dylib`Mutex::lock(Thread*) + 44
    frame #4: 0x0000000103de41a0 libjvm.dylib`VM_Exit::wait_if_vm_exited() + 72
    frame #5: 0x00000001039fea24 libjvm.dylib`jni_DetachCurrentThread + 92
    frame #6: 0x000000013828afbc libforstjni-osx-arm64.jnilib`forstdb::JavaEnv::~JavaEnv() [inlined] JavaVM_::DetachCurrentThread(this=<unavailable>) at jni.h:1917:16 [opt]
    frame #7: 0x000000013828afb0 libforstjni-osx-arm64.jnilib`forstdb::JavaEnv::~JavaEnv() [inlined] forstdb::JavaEnv::~JavaEnv(this=0x000000014d018318) at jvm_util.h:61:20 [opt]
    frame #8: 0x000000013828af94 libforstjni-osx-arm64.jnilib`forstdb::JavaEnv::~JavaEnv(this=0x000000014d018318) at jvm_util.h:59:14 [opt]
    frame #9: 0x000000018b9e2364 dyld`invocation function for block in dyld4::RuntimeState::_finalizeListTLV(void*) + 56
    frame #10: 0x000000018b9e22cc dyld`dyld4::RuntimeState::_finalizeListTLV(void*) + 116
    frame #11: 0x000000018bd298ec libsystem_pthread.dylib`_pthread_tsd_cleanup + 488
    frame #12: 0x000000018bd2c69c libsystem_pthread.dylib`_pthread_exit + 84
    frame #13: 0x000000018bd2bfb4 libsystem_pthread.dylib`_pthread_start + 160
```
Which, I guess by the method name, means the background threads are waiting for the VM quit. While the VM thread is quitting, invoking the desconstructor of the `Env`, it is joining the background threads:
```
  thread #6, name = 'Java: VM Thread'
    frame #0: 0x000000018bcedd10 libsystem_kernel.dylib`__ulock_wait + 8
    frame #1: 0x000000018bd2e338 libsystem_pthread.dylib`_pthread_join + 440
    frame #2: 0x000000018bc62934 libc++.1.dylib`std::__1::thread::join() + 36
    frame #3: 0x00000001383cd1f4 libforstjni-osx-arm64.jnilib`forstdb::ThreadPoolImpl::Impl::JoinThreads(this=0x0000600001915a40, wait_for_jobs_to_complete=<unavailable>) at threadpool_imp.cc:197:8 [opt]
    frame #4: 0x0000000138263240 libforstjni-osx-arm64.jnilib`forstdb::(anonymous namespace)::PosixEnv::JoinThreadsOnExit::~JoinThreadsOnExit() at env_posix.cc:225:38 [opt]
    frame #5: 0x00000001382631cc libforstjni-osx-arm64.jnilib`forstdb::(anonymous namespace)::PosixEnv::JoinThreadsOnExit::~JoinThreadsOnExit(this=0x0000000138626678) at env_posix.cc:220:26 [opt]
    frame #6: 0x000000018bbe9ec4 libsystem_c.dylib`__cxa_finalize_ranges + 476
    frame #7: 0x000000018bbe9c4c libsystem_c.dylib`exit + 44
    frame #8: 0x0000000103c301fc libjvm.dylib`os::exit(int) + 12
    frame #9: 0x0000000103de4148 libjvm.dylib`VM_Exit::doit() + 160
    frame #10: 0x0000000103de3694 libjvm.dylib`VM_Operation::evaluate() + 240
    frame #11: 0x0000000103def45c libjvm.dylib`VMThread::evaluate_operation(VM_Operation*) + 240
    frame #12: 0x0000000103defa94 libjvm.dylib`VMThread::inner_execute(VM_Operation*) + 456
    frame #13: 0x0000000103def294 libjvm.dylib`VMThread::loop() + 92
    frame #14: 0x0000000103def12c libjvm.dylib`VMThread::run() + 140
    frame #15: 0x0000000103d8e53c libjvm.dylib`Thread::call_run() + 140
    frame #16: 0x0000000103c2a8a4 libjvm.dylib`thread_native_entry(Thread*) + 204
    frame #17: 0x000000018bd2bfa8 libsystem_pthread.dylib`_pthread_start + 148
```
Thus the VM thread and background thread are waiting for each other, there is a deadlock.

This PR introduces a shutdown hook in JVM, to join the background threads before the VM quit. By this way we break the deadlock and let JVM quits smoothly.

## Brief change log

 - A shutdown hook to join the background threads.

## Verifying this change

This change is verified manually.