### PR TITLE
Add RocksDBShutdownHook to CMake build configuration

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -230,6 +230,7 @@ set(JAVA_MAIN_CLASSES
         src/main/java/org/forstdb/ReusedSynchronisationType.java
         src/main/java/org/forstdb/RocksCallbackObject.java
         src/main/java/org/forstdb/RocksDBException.java
+        src/main/java/org/forstdb/RocksDBShutdownHook.java
         src/main/java/org/forstdb/RocksDB.java
         src/main/java/org/forstdb/RocksEnv.java
         src/main/java/org/forstdb/RocksIteratorInterface.java


### PR DESCRIPTION


<!--
*Thank you very much for contributing to ForSt.

## Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - The title of this PR should start with module name, such as [build] / [core] / [JNI] ...
-->

## What is the purpose of the change

Add RocksDBShutdownHook.java to JAVA_MAIN_CLASSES list in CMakeLists.txt to resolve compilation errors related to missing symbol references in RocksDB.java.
<img width="469" alt="image" src="https://github.com/user-attachments/assets/82057ab8-0fb0-421c-9af8-557d4a8e23ab" />


## Brief change log

- Add RocksDBShutdownHook.java to JAVA_MAIN_CLASSES list in CMakeLists.txt.


## Verifying this change

This change is a code cleanup without any test coverage.