### PR TITLE
[Flink] Close WritableFile when destroy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 #-----------------------------------------------
 
-FORST_VERSION ?= 0.1.6
+FORST_VERSION ?= 0.1.7
 
 BASH_EXISTS := $(shell which bash)
 SHELL := $(shell which bash)


### PR DESCRIPTION
## What is the purpose of the change

Currently, `FSWritableFile`  is not ensured closed when destroy. But in ForSt/RocksDB it is possible that a file is destroyed without a manual close.

## Brief change log

 - deconstructor of `FSWritableFile`
 - bump a version