### PR TITLE
[Flink] Initialize the stream pointer in constructor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 #-----------------------------------------------
 
-FORST_VERSION ?= 0.1.7
+FORST_VERSION ?= 0.1.8
 
 BASH_EXISTS := $(shell which bash)
 SHELL := $(shell which bash)

--- a/env/flink/env_flink.cc
+++ b/env/flink/env_flink.cc
@@ -44,6 +44,7 @@ class FlinkWritableFile : public FSWritableFile {
       : FSWritableFile(options),
         file_path_(file_path),
         file_system_instance_(file_system_instance),
+        fs_data_output_stream_instance_(nullptr),
         class_cache_(java_class_cache),
         closed_(false) {}
 
@@ -175,6 +176,7 @@ class FlinkReadableFile : virtual public FSSequentialFile,
                     const std::string& file_path)
       : file_path_(file_path),
         file_system_instance_(file_system_instance),
+        fs_data_input_stream_instance_(nullptr),
         class_cache_(java_class_cache) {}
 
   ~FlinkReadableFile() override {


### PR DESCRIPTION
## What is the purpose of the change

 This PR put initialization of pointers for ForSt stream, to avoid unexpected memory leak or core dumps.