### PR TITLE
Upgrade macOS version and Xcode in workflows

### DIFF
--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -112,7 +112,7 @@ jobs:
 
   # ========================= MacOS build only ======================== #
   build-macos:
-    runs-on: macos-13
+    runs-on: macos-15
     timeout-minutes: 120
     env:
       ROCKSDB_DISABLE_JEMALLOC: 1
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v4.1.0
       - uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
-          xcode-version: 14.3.1
+          xcode-version: 16.4.0
       - uses: "./.github/actions/increase-max-open-files-on-macos"
       - uses: "./.github/actions/install-gflags-on-macos"
       - uses: "./.github/actions/pre-steps-macos"
@@ -129,7 +129,7 @@ jobs:
       - uses: "./.github/actions/post-steps"
   # ========================= MacOS with java ======================== #
   build-macos-java:
-    runs-on: macos-13
+    runs-on: macos-15
     env:
       JAVA_HOME: "/Library/Java/JavaVirtualMachines/liberica-jdk-8.jdk/Contents/Home"
       ROCKSDB_DISABLE_JEMALLOC: 1
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v4.1.0
       - uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
-          xcode-version: 14.3.1
+          xcode-version: 16.4.0
       - uses: "./.github/actions/increase-max-open-files-on-macos"
       - uses: "./.github/actions/install-gflags-on-macos"
       - uses: "./.github/actions/install-jdk8-on-macos"
@@ -151,14 +151,14 @@ jobs:
         run: DISABLE_WARNING_AS_ERROR=1 DISABLE_PERF_CONTEXT=0 make V=1 J=16 -j16 jtest
       - uses: "./.github/actions/post-steps"
   build-macos-java-static:
-    runs-on: macos-13
+    runs-on: macos-15
     env:
       JAVA_HOME: "/Library/Java/JavaVirtualMachines/liberica-jdk-8.jdk/Contents/Home"
     steps:
       - uses: actions/checkout@v4.1.0
       - uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
-          xcode-version: 14.3.1
+          xcode-version: 16.4.0
       - uses: "./.github/actions/increase-max-open-files-on-macos"
       - uses: "./.github/actions/install-gflags-on-macos"
       - uses: "./.github/actions/install-jdk8-on-macos"


### PR DESCRIPTION
macos-13 is no longer available since December 4th

2025 actions/runner-images#13046