### PR TITLE
[build] Update README.md to clarify words related to Apache Flink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## ForSt: A Persistent Key-Value Store designed for Streaming processing
 
-ForSt is developed and maintained by Flink community and hosted by ververica.
+ForSt is currently hosted by Ververica.
 It is built on top of [RocksDB](https://github.com/facebook/rocksdb) by facebook.
 
 This code is a library that forms the core building block for a fast


### PR DESCRIPTION
update the host information

This PR updates the README.md to comply with ASF (Apache Software Foundation) trademark guidelines by removing the phrase "developed and maintained by Flink community" from the project description. This clarifies the project's relationship with Apache Flink while maintaining factual information about the project's hosting.

Changes made:
Removed reference to "developed and maintained by Flink community" from the project description to avoid trademark confusion. Simplified the description to state only that "ForSt is hosted by ververica"
